### PR TITLE
Add short argument flags

### DIFF
--- a/make-m65-symbols.py
+++ b/make-m65-symbols.py
@@ -437,13 +437,16 @@ def main():
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
+        '-f',
         '--format',
         choices=FORMATS.keys(),
         help='The output format')
     parser.add_argument(
+        '-o',
         '--output-file',
         help='The symbols output file path')
     parser.add_argument(
+        '-i',
         '--iomap-file',
         help='The iomap.txt file path')
     parser.add_argument(


### PR DESCRIPTION
Hi Dan, I add short argument options as I find it easier to remember `-i`, `-o`, and `-f`. I think these are quite general for at least input (i) and output (o) across many cli tools.